### PR TITLE
BufWriter also for fasta (from redux)

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -101,5 +101,7 @@ fn run<W: io::Write>(writer: &mut W) -> io::Result<()> {
 }
 
 fn main() {
-    run(&mut io::stdout()).unwrap()
+    let out = io::stdout();
+    let mut outlocked = io::BufWriter::new(out.lock());
+    run(&mut outlocked).unwrap()
 }


### PR DESCRIPTION
Same old, same old :smile:

On my machine – Before:

```
real    0m4.612s
user    0m4.032s
sys     0m0.576s
```

After:

```
real    0m3.533s
user    0m3.528s
sys     0m0.000s
```
