### PR TITLE
portable dependency trickery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ RUSTC_FLAGS ?= -C opt-level=3 -C target-cpu=core2 -C lto
 RUSTC_FLAGS += -L ./lib
 REGEX ?= regex-0.1.41
 ARENA ?= typed-arena-1.0.1
+NUM_CPU ?= num_cpus-0.2.6
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -25,16 +26,22 @@ diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 
 bin/binary_trees: src/binary_trees.rs lib/$(ARENA).pkg
 
+bin/fasta: src/fasta.rs lib/$(NUM_CPU).pkg
+
+bin/fasta_redux: src/fasta_redux.rs lib/$(NUM_CPU).pkg
+
 bin/regex_dna: src/regex_dna.rs lib/$(REGEX).pkg
 
 lib/%.pkg:
-	mkdir -p tmp
-	rm -rf tmp/$(call crate,$*)-deps
-	cargo new tmp/$(call crate,$*)-deps
-	echo '\n[dependencies]\n$(call crate,$*) = "$(call version,$*)"' >> tmp/$(call crate,$*)-deps/Cargo.toml
-	cargo build --release --manifest-path tmp/$(call crate,$*)-deps/Cargo.toml
-	mkdir -p lib
-	cp tmp/$(call crate,$*)-deps/target/release/deps/* lib/
+	@mkdir -p tmp
+	@rm -rf tmp/$(call crate,$*)-deps
+	@cargo new tmp/$(call crate,$*)-deps
+	@echo >> tmp/$(call crate,$*)-deps/Cargo.toml
+	@echo '[dependencies]' >> tmp/$(call crate,$*)-deps/Cargo.toml
+	@echo '$(call crate,$*) = "$(call version,$*)"' >> tmp/$(call crate,$*)-deps/Cargo.toml
+	@cargo build --release --manifest-path tmp/$(call crate,$*)-deps/Cargo.toml
+	@mkdir -p lib
+	@cp tmp/$(call crate,$*)-deps/target/release/deps/* lib/
 	@touch lib/$*.pkg
 
 bin/%: src/%.rs

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,14 @@ bin/fasta_redux: src/fasta_redux.rs lib/$(NUM_CPU).pkg
 bin/regex_dna: src/regex_dna.rs lib/$(REGEX).pkg
 
 lib/%.pkg:
-	@mkdir -p tmp
-	@rm -rf tmp/$(call crate,$*)-deps
-	@cargo new tmp/$(call crate,$*)-deps
-	@echo >> tmp/$(call crate,$*)-deps/Cargo.toml
-	@echo '[dependencies]' >> tmp/$(call crate,$*)-deps/Cargo.toml
-	@echo '$(call crate,$*) = "$(call version,$*)"' >> tmp/$(call crate,$*)-deps/Cargo.toml
-	@cargo build --release --manifest-path tmp/$(call crate,$*)-deps/Cargo.toml
-	@mkdir -p lib
-	@cp tmp/$(call crate,$*)-deps/target/release/deps/* lib/
-	@touch lib/$*.pkg
+	mkdir -p tmp
+	rm -rf tmp/$(call crate,$*)-deps
+	cargo new tmp/$(call crate,$*)-deps
+	printf '\n[dependencies]\n$(call crate,$*) = "$(call version,$*)"\n' >> tmp/$(call crate,$*)-deps/Cargo.toml
+	cargo build --release --manifest-path tmp/$(call crate,$*)-deps/Cargo.toml
+	mkdir -p lib
+	cp tmp/$(call crate,$*)-deps/target/release/deps/* lib/
+	touch lib/$*.pkg
 
 bin/%: src/%.rs
 	mkdir -p bin


### PR DESCRIPTION
This fixes #18. Also it pulls in the num_cpus crate for fasta and fasta_redux (in preparation of the next PR :smile: )
