### PR TITLE
Re-wrote k_nucleotide

### DIFF
--- a/src/k_nucleotide.rs
+++ b/src/k_nucleotide.rs
@@ -3,273 +3,306 @@
 //
 // contributed by the Rust Project Developers
 // contributed by TeXitoi
+// contributed by Joshua Landau
 
-use std::slice;
+mod sequence {
+    use std::iter;
+    use std::slice;
+
+    fn pack_byte(byte: u8, offset: usize) -> u64 {
+        // {a: 0, c: 1, t: 2, g: 3}[byte.lower()] << offset
+        (((byte >> 1) & 0b11) as u64) << offset
+    }
+
+    fn unpack_byte(packed: u64, offset: u8) -> char {
+        ['A', 'C', 'T', 'G'][((packed >> offset) & 0b11) as usize]
+    }
+
+    pub struct Sequence {
+        data: Vec<u64>,
+        bit_len: usize,
+    }
+
+    impl Sequence {
+        pub fn new() -> Sequence {
+            Sequence { data: vec![0, 0], bit_len: 0 }
+        }
+
+        // Yes, this is hilarious
+        pub fn eat(&mut self, cereal: &[u8]) {
+            let mut start = self.bit_len;
+            let mut working = self.data[start / 64];
+
+            for &byte in cereal {
+                // Pack amino acid
+                working |= pack_byte(byte, start % 64);
+                start += 2;
+
+                if start % 64 == 0 {
+                    self.data[start / 64 - 1] = working;
+                    working = 0;
+                    self.data.push(0);
+                    // self.data has two trailing 0s
+                }
+            }
+
+            self.data[start / 64] = working;
+            self.bit_len = start;
+        }
+
+        pub fn sub_sequences(&self, size: u8) -> SubSequences {
+            if !(0 < size && size <= 32) {
+                panic!("Size must be 0 < size <= 32");
+            }
+
+            let mut data = self.data.iter().cloned();
+            let first = data.next().unwrap();
+            SubSequences {
+                left: 0,
+                right: first,
+                data: data,
+                shift_out: 64 - (size * 2),
+                bit_start: 0,
+                bit_end: self.bit_len - (size * 2) as usize,
+            }
+        }
+    }
+
+
+    #[derive(Copy, Clone, Default, Eq, PartialEq)]
+    pub struct SubSequence(u64);
+
+    impl SubSequence {
+        pub fn from_bytes(cereal: &[u8]) -> SubSequence {
+            let mut sequence = Sequence::new();
+            sequence.eat(cereal);
+            sequence.sub_sequences(cereal.len() as u8).next().unwrap()
+        }
+
+        pub fn hash(&self) -> u64 {
+            match *self { SubSequence(hash) => hash }
+        }
+
+        pub fn to_string(&self, length: u8) -> String {
+            ((32-length)..32).map(|i| unpack_byte(self.hash(), 2 * i)).collect()
+        }
+    }
+
+    pub struct SubSequences<'a> {
+        left: u64,
+        right: u64,
+        data: iter::Cloned<slice::Iter<'a, u64>>,
+        shift_out: u8,
+        bit_start: usize,
+        bit_end: usize,
+    }
+
+    impl<'a> Iterator for SubSequences<'a> {
+        type Item = SubSequence;
+
+        fn next(&mut self) -> Option<SubSequence> {
+            if !(self.bit_start <= self.bit_end) {
+                return None;
+            }
+
+            let packed = match self.bit_start % 64 {
+                0 => {
+                    self.left = self.right;
+                    self.right = self.data.next().unwrap();
+                    self.left
+                },
+                shift => (self.left >> shift) | (self.right << (64 - shift))
+            };
+
+            self.bit_start += 2;
+            Some(SubSequence(packed << self.shift_out))
+        }
+    }
+}
+
+
+// Can't use the built-in HashMap since custom hashers haven't been stabilized.
+mod counter {
+    use std::cmp;
+    use std::iter;
+    use std::slice;
+    use sequence::SubSequence;
+
+    const DEFAULT_LOG: u8 = 8;
+    const GROWTH_LOG: u8 = 3;
+    const BUFFER_LEN: usize = 8;
+
+    #[derive(Copy, Clone, Default)]
+    pub struct Entry {
+        pub key: SubSequence,
+        pub count: usize,
+    }
+
+    pub struct Counter {
+        slots: Vec<Entry>,
+        hash_offset: u8,
+    }
+
+    impl Counter {
+        pub fn new() -> Counter {
+            Counter {
+                slots: vec![Default::default(); BUFFER_LEN + (1 << DEFAULT_LOG)],
+                hash_offset: 64 - DEFAULT_LOG,
+            }
+        }
+
+        // Robin Hood Hash
+        pub fn increment(&mut self, key: SubSequence) -> usize {
+            let mut new = Entry { key: key, count: 1 };
+
+            loop {
+                let start = (new.key.hash() >> self.hash_offset) as usize;
+                for search_pos in start..(start + 8) {
+                    let entry = self.slots[search_pos];
+
+                    if entry.count == 0 {
+                        self.slots[search_pos] = new;
+                        return 0;
+                    }
+                    else if entry.key == new.key {
+                        self.slots[search_pos].count = entry.count + new.count;
+                        return entry.count;
+                    }
+                    else if entry.key.hash() > new.key.hash() {
+                        self.slots[search_pos] = new;
+                        new = entry;
+                    }
+                }
+
+                self.resize();
+            }
+        }
+
+        #[inline(never)]
+        fn resize(&mut self) {
+            self.hash_offset -= GROWTH_LOG;
+            let len = self.slots.len() - BUFFER_LEN;
+            let mut new = vec![Default::default(); (len << GROWTH_LOG) + BUFFER_LEN];
+
+            let mut next_empty = 0;
+            for entry in self.iter() {
+                let search_pos = entry.key.hash() >> self.hash_offset;
+                let insert_at = cmp::max(next_empty, search_pos as usize);
+                new[insert_at] = entry;
+                next_empty = insert_at + 1;
+            }
+
+            self.slots = new;
+        }
+
+        pub fn iter(&self) -> Iter {
+            Iter(self.slots.iter().cloned())
+        }
+    }
+
+    pub struct Iter<'a>(iter::Cloned<slice::Iter<'a, Entry>>);
+
+    impl<'a> Iterator for Iter<'a> {
+        type Item = Entry;
+
+        fn next(&mut self) -> Option<Entry> {
+            self.0.find(|&x| x.count != 0)
+        }
+    }
+}
+
+
+
+use counter::Counter;
+use sequence::{Sequence, SubSequence};
+
+use std::io;
 use std::sync::Arc;
 use std::thread;
 
-static TABLE: [u8;4] = [ 'A' as u8, 'C' as u8, 'G' as u8, 'T' as u8 ];
-static TABLE_SIZE: usize = 2 << 16;
+fn get_sequence<R: std::io::BufRead>(mut input: R, key: &[u8]) -> io::Result<Sequence> {
+    let mut sequence = Sequence::new();
+    let mut line = Vec::new();
 
-static OCCURRENCES: [&'static str;5] = [
-    "GGT",
-    "GGTA",
-    "GGTATT",
-    "GGTATTTTAATT",
-    "GGTATTTTAATTTATAGT",
-];
-
-// Code implementation
-
-#[derive(PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]
-struct Code(u64);
-
-impl Code {
-    fn hash(&self) -> u64 {
-        let Code(ret) = *self;
-        return ret;
+    while !line.starts_with(key) {
+        line.truncate(0);
+        try!(input.read_until(b'\n', &mut line));
     }
 
-    fn push_char(&self, c: u8) -> Code {
-        Code((self.hash() << 2) + (pack_symbol(c) as u64))
-    }
-
-    fn rotate(&self, c: u8, frame: usize) -> Code {
-        Code(self.push_char(c).hash() & ((1u64 << (2 * frame)) - 1))
-    }
-
-    fn pack(string: &str) -> Code {
-        string.bytes().fold(Code(0u64), |a, b| a.push_char(b))
-    }
-
-    fn unpack(&self, frame: usize) -> String {
-        let mut key = self.hash();
-        let mut result = Vec::new();
-        for _ in (0..frame) {
-            result.push(unpack_symbol((key as u8) & 3));
-            key >>= 2;
+    loop {
+        line.truncate(0);
+        try!(input.read_until(b'\n', &mut line));
+        if line.is_empty() || line.starts_with(b">") {
+            break;
         }
-
-        result.reverse();
-        String::from_utf8(result).unwrap()
-    }
-}
-
-// Hash table implementation
-
-trait TableCallback {
-    fn f(&self, entry: &mut Entry);
-}
-
-struct BumpCallback;
-
-impl TableCallback for BumpCallback {
-    fn f(&self, entry: &mut Entry) {
-        entry.count += 1;
-    }
-}
-
-struct PrintCallback(&'static str);
-
-impl TableCallback for PrintCallback {
-    fn f(&self, entry: &mut Entry) {
-        let PrintCallback(s) = *self;
-        println!("{}\t{}", entry.count, s);
-    }
-}
-
-struct Entry {
-    code: Code,
-    count: usize,
-    next: Option<Box<Entry>>,
-}
-
-struct Table {
-    items: Vec<Option<Box<Entry>>>
-}
-
-struct Items<'a> {
-    cur: Option<&'a Entry>,
-    items: slice::Iter<'a, Option<Box<Entry>>>,
-}
-
-impl Table {
-    fn new() -> Table {
-        Table {
-            items: (0..TABLE_SIZE).map(|_| None).collect()
+        if line.ends_with(b"\n") {
+            line.pop();
         }
+        sequence.eat(&line);
     }
 
-    fn search_remainder<C:TableCallback>(item: &mut Entry, key: Code, c: C) {
-        match item.next {
-            None => {
-                let mut entry = Box::new(Entry {
-                    code: key,
-                    count: 0,
-                    next: None,
-                });
-                c.f(&mut *entry);
-                item.next = Some(entry);
-            }
-            Some(ref mut entry) => {
-                if entry.code == key {
-                    c.f(&mut **entry);
-                    return;
-                }
-
-                Table::search_remainder(&mut **entry, key, c)
-            }
-        }
-    }
-
-    fn lookup<C:TableCallback>(&mut self, key: Code, c: C) {
-        let index = key.hash() % (TABLE_SIZE as u64);
-
-        {
-            if self.items[index as usize].is_none() {
-                let mut entry = Box::new(Entry {
-                    code: key,
-                    count: 0,
-                    next: None,
-                });
-                c.f(&mut *entry);
-                self.items[index as usize] = Some(entry);
-                return;
-            }
-        }
-
-        {
-            let entry = self.items[index as usize].as_mut().unwrap();
-            if entry.code == key {
-                c.f(&mut **entry);
-                return;
-            }
-
-            Table::search_remainder(&mut **entry, key, c)
-        }
-    }
-
-    fn iter(&self) -> Items {
-        Items { cur: None, items: self.items.iter() }
-    }
+    Ok(sequence)
 }
 
-impl<'a> Iterator for Items<'a> {
-    type Item = &'a Entry;
-
-    fn next(&mut self) -> Option<&'a Entry> {
-        let ret = match self.cur {
-            None => {
-                let i;
-                loop {
-                    match self.items.next() {
-                        None => return None,
-                        Some(&None) => {}
-                        Some(&Some(ref a)) => { i = &**a; break }
-                    }
-                }
-                self.cur = Some(&*i);
-                &*i
-            }
-            Some(c) => c
-        };
-        match ret.next {
-            None => { self.cur = None; }
-            Some(ref next) => { self.cur = Some(&**next); }
-        }
-        return Some(ret);
+fn build_counter(sequence: &Arc<Sequence>, size: u8) -> Counter {
+    let mut counter = Counter::new();
+    for sub_genome in sequence.sub_sequences(size) {
+        counter.increment(sub_genome);
     }
+    counter
 }
 
-// Main program
+fn of_size(sequence: &Arc<Sequence>, size: u8) -> String {
+    let counter = build_counter(sequence, size);
+    let mut entries: Vec<_> = counter.iter().collect();
 
-fn pack_symbol(c: u8) -> u8 {
-    match c as char {
-        'A' => 0,
-        'C' => 1,
-        'G' => 2,
-        'T' => 3,
-        _ => panic!("{}", c as char),
-    }
+    entries.sort_by(|x, y| y.count.cmp(&x.count));
+    let total_count = entries.iter().fold(0, |tot, e| tot + e.count);
+
+    entries.iter().map(|entry| format!("{} {:.3}\n",
+        entry.key.to_string(size),
+        (entry.count as f64) / (total_count as f64) * 100.0
+    )).fold(String::new(), |a, b| a + &b)
 }
 
-fn unpack_symbol(c: u8) -> u8 {
-    TABLE[c as usize]
-}
-
-fn generate_frequencies(mut input: &[u8], frame: usize) -> Table {
-    let mut frequencies = Table::new();
-    if input.len() < frame { return frequencies; }
-    let mut code = Code(0);
-
-    // Pull first frame.
-    for _ in (0..frame) {
-        code = code.push_char(input[0]);
-        input = &input[1..];
-    }
-    frequencies.lookup(code, BumpCallback);
-
-    while input.len() != 0 && input[0] != ('>' as u8) {
-        code = code.rotate(input[0], frame);
-        frequencies.lookup(code, BumpCallback);
-        input = &input[1..];
-    }
-    frequencies
-}
-
-fn print_frequencies(frequencies: &Table, frame: usize) {
-    let mut vector = Vec::new();
-    for entry in frequencies.iter() {
-        vector.push((entry.count, entry.code));
-    }
-    vector.sort();
-
-    let mut total_count = 0;
-    for &(count, _) in vector.iter() {
-        total_count += count;
-    }
-
-    for &(count, key) in vector.iter().rev() {
-        println!("{} {:.3}",
-                 key.unpack(frame),
-                 (count as f32 * 100.0) / (total_count as f32));
-    }
-    println!("");
-}
-
-fn print_occurrences(frequencies: &mut Table, occurrence: &'static str) {
-    frequencies.lookup(Code::pack(occurrence), PrintCallback(occurrence))
-}
-
-fn get_sequence<R: std::io::BufRead>(r: R, key: &str) -> Vec<u8> {
-    let mut res = Vec::new();
-    for l in r.lines().map(|l| l.ok().unwrap())
-        .skip_while(|l| key != &l[..key.len()]).skip(1)
-    {
-        use std::ascii::AsciiExt;
-        res.extend(l.trim().as_bytes().iter().map(|b| b.to_ascii_uppercase()));
-    }
-    res
+fn of_string(sequence: &Arc<Sequence>, string: &str) -> String {
+    let bytes = string.as_bytes();
+    let mut counter = build_counter(sequence, bytes.len() as u8);
+    let count = counter.increment(SubSequence::from_bytes(bytes));
+    format!("{}\t{}", count, string)
 }
 
 fn main() {
     let stdin = std::io::stdin();
-    let input = get_sequence(stdin.lock(), ">THREE");
-    let input = Arc::new(input);
+    let sequence = Arc::new(get_sequence(stdin.lock(), b">THREE").unwrap());
+    let mut threads = Vec::new();
 
-    let nb_freqs: Vec<_> = (1usize..3).map(|i| {
-        let input = input.clone();
-        (i, thread::spawn(move|| generate_frequencies(&input, i)))
-    }).collect();
-    let occ_freqs: Vec<_> = OCCURRENCES.iter().map(|&occ| {
-        let input = input.clone();
-        thread::spawn(move|| generate_frequencies(&input, occ.len()))
-    }).collect();
+    let seq = sequence.clone();
+    threads.push(thread::spawn(move || vec![
+        of_size(&seq, 1),
+        of_size(&seq, 2),
+        of_string(&seq, "GGT")
+    ]));
 
-    for (i, freq) in nb_freqs.into_iter() {
-        print_frequencies(&freq.join().unwrap(), i);
-    }
-    for (&occ, freq) in OCCURRENCES.iter().zip(occ_freqs.into_iter()) {
-        print_occurrences(&mut freq.join().unwrap(), occ);
+    let seq = sequence.clone();
+    threads.push(thread::spawn(move || vec![
+        of_string(&seq, "GGTA"),
+        of_string(&seq, "GGTATT")
+    ]));
+
+    let seq = sequence.clone();
+    threads.push(thread::spawn(move || vec![
+        of_string(&seq, "GGTATTTTAATT")
+    ]));
+
+    let seq = sequence.clone();
+    threads.push(thread::spawn(move || vec![
+        of_string(&seq, "GGTATTTTAATTTATAGT")
+    ]));
+
+    for thread in threads {
+        for line in thread.join().unwrap() {
+            println!("{}", line);
+        }
     }
 }


### PR DESCRIPTION
This is a complete rewrite of `k_nucleotide.rs`, staying largely on the original's lines. The important changes are
- an improved hash table, using flat Robin Hood Hashing,
- pre-compacted input,
- better load balanced threading,
- really cool `pack_byte` implementation.

I'll submit this (and the new `thread-ring.rs`) to Rust later, and the Benchmarks Game after.

One quick question: did I get the attribution right? Should I have dropped "contributed by TeXitoi"? Or should I just let TeXitoi submit it? ;P
