### PR TITLE
autovectorize spectralnorm

### DIFF
--- a/src/spectralnorm.rs
+++ b/src/spectralnorm.rs
@@ -93,7 +93,7 @@ fn mult<F>(v: &[f64], out: &mut [f64], start: usize, a: F)
         let mut sum = f64x2(0.0, 0.0);
         for (j, chunk) in v.chunks(2).enumerate().map(|(j, s)| (2 * j, s)) {
             let top = f64x2(chunk[0], chunk[1]);
-            let bot = a(usizex2(i, i), usizex2(j, j+1)); //f64x2(a(i, j), a(i, j + 1));
+            let bot = a(usizex2(i, i), usizex2(j, j+1));
             sum = sum + top / bot;
         }
         let f64x2(a, b) = sum;


### PR DESCRIPTION
I just added @teXitoi's autovectorization suggestion to spectralnorm. This closes #9 

Measurements are promising:

```
$ time bin/spectralnorm_old 5500
1.274224153

real    0m2.496s
user    0m9.159s
sys     0m0.022s

$ time bin/spectralnorm 5500
1.274224153

real    0m2.061s
user    0m7.263s
sys     0m0.027s
```

Since Rust uses the as-of-yet unstable simd types, there's little point in suggesting they update to this.
