### PR TITLE
fix broken Cargo.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lib/%.pkg:
 	mkdir -p tmp
 	rm -rf tmp/$(call crate,$*)-deps
 	cargo new tmp/$(call crate,$*)-deps
-	printf '\n[dependencies]\n$(call crate,$*) = "$(call version,$*)"\n' >> tmp/$(call crate,$*)-deps/Cargo.toml
+	printf '$(call crate,$*) = "$(call version,$*)"\n' >> tmp/$(call crate,$*)-deps/Cargo.toml
 	cargo build --release --manifest-path tmp/$(call crate,$*)-deps/Cargo.toml
 	mkdir -p lib
 	cp tmp/$(call crate,$*)-deps/target/release/deps/* lib/


### PR DESCRIPTION
Cargo.toml already has a `[dependency]` line when doing a `cargo new`.
