### PR TITLE
k_nucleotide: rewrite for compliance of the new rules and performances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ RUSTC_FLAGS ?= -C opt-level=3 -C target-cpu=core2 -C lto
 RUSTC_FLAGS += -L ./lib
 REGEX ?= regex-0.1.69
 ARENA ?= typed-arena-1.1.0
-NUM_CPU ?= num_cpus-0.2.11
+NUM_CPU ?= num_cpus-1.2.1
+FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -29,6 +30,8 @@ bin/binary_trees: src/binary_trees.rs lib/$(ARENA).pkg
 bin/fasta: src/fasta.rs lib/$(NUM_CPU).pkg
 
 bin/fasta_redux: src/fasta_redux.rs lib/$(NUM_CPU).pkg
+
+bin/k_nucleotide: src/k_nucleotide.rs lib/$(FUTURES_CPUPOOL).pkg
 
 bin/regex_dna: src/regex_dna.rs lib/$(REGEX).pkg
 

--- a/src/k_nucleotide.rs
+++ b/src/k_nucleotide.rs
@@ -9,13 +9,13 @@ use std::thread;
 use std::hash::{Hasher, BuildHasherDefault};
 use std::collections::HashMap;
 
-struct CustomHasher(u64);
-impl Default for CustomHasher {
+struct NaiveHasher(u64);
+impl Default for NaiveHasher {
     fn default() -> Self {
-        CustomHasher(0)
+        NaiveHasher(0)
     }
 }
-impl Hasher for CustomHasher {
+impl Hasher for NaiveHasher {
     fn finish(&self) -> u64 {
         self.0
     }
@@ -26,9 +26,9 @@ impl Hasher for CustomHasher {
         self.0 = i ^ i >> 7;
     }
 }
-type CustomBuildHasher = BuildHasherDefault<CustomHasher>;
-type CustomHashMap<K, V> = HashMap<K, V, CustomBuildHasher>;
-type Map = CustomHashMap<Code, u32>;
+type NaiveBuildHasher = BuildHasherDefault<NaiveHasher>;
+type NaiveHashMap<K, V> = HashMap<K, V, NaiveBuildHasher>;
+type Map = NaiveHashMap<Code, u32>;
 
 static OCCURRENCES: [&'static str; 5] = [
     "GGT",


### PR DESCRIPTION
To everyone watching this project, please review this code. @llogiq @BurntSushi @Veedrac ?

In particular, I'm not found of my hand scheduling "there is 4 CPU, thus launch the 3 more costy jobs in their own thread and do the rest syncronously".

Performances on the output of fasta 25000000:

| Version | Real | User | Sys |
| --------- | ------ | ------ | ----- |
| this repo version (no rules compliant) | 0m5.850s | 0m20.700s | 0m0.096s |
| current rust version on benchmarksgame | 0m8.391s | 0m26.832s | 0m0.144s |
| proposed version | 0m4.855s | 0m12.800s | 0m0.080s |

Thanks for your time.