### PR TITLE
k_nucleotide: user `OrderMap` and skip UTF-8 validation in `get_seq`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REGEX ?= regex-0.1.69
 ARENA ?= typed-arena-1.1.0
 NUM_CPU ?= num_cpus-1.2.1
 FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
+ORDERMAP ?= ordermap-0.2.7
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -23,7 +24,7 @@ distclean: clean
 bin/binary_trees: lib/$(ARENA).pkg
 bin/fasta: lib/$(NUM_CPU).pkg
 bin/fasta_redux: lib/$(NUM_CPU).pkg
-bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg
+bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(FUTURES_CPUPOOL).pkg
 bin/regex_dna: lib/$(REGEX).pkg
 

--- a/src/k_nucleotide.rs
+++ b/src/k_nucleotide.rs
@@ -6,13 +6,14 @@
 
 extern crate futures;
 extern crate futures_cpupool;
+extern crate ordermap;
 
 use std::sync::Arc;
 use std::hash::{Hasher, BuildHasherDefault};
-use std::collections::HashMap;
 use futures::Future;
 use futures_cpupool::CpuPool;
 use Item::*;
+use ordermap::OrderMap;
 
 struct NaiveHasher(u64);
 impl Default for NaiveHasher {
@@ -32,7 +33,7 @@ impl Hasher for NaiveHasher {
     }
 }
 type NaiveBuildHasher = BuildHasherDefault<NaiveHasher>;
-type NaiveHashMap<K, V> = HashMap<K, V, NaiveBuildHasher>;
+type NaiveHashMap<K, V> = OrderMap<K, V, NaiveBuildHasher>;
 type Map = NaiveHashMap<Code, u32>;
 
 #[derive(Hash, PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]


### PR DESCRIPTION
`OrderMap` is the big change which on my computer brings the runtime down from ~5.2s to ~3.5s. Operating on bytes directly when reading the input (second commit) shaves off a further 0.2s roughly.

I don't see why this library would not be accepted, it's been around for a while and it wasn't written for this benchmark in the slightest---or for this kind of task in general. In fact, as far as I can tell, its main design goal is to be ordered, not necessarily to be faster than std.