### PR TITLE
reverse_complement: More paralellism and safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ NUM_CPU ?= num_cpus-1.2.1
 FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
 RAYON ?= rayon-0.6
 ORDERMAP ?= ordermap-0.2.7
+CROSSBEAM ?= crossbeam-0.2
+LIBC ?= libc-0.2
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -28,6 +30,7 @@ bin/fasta_redux: lib/$(NUM_CPU).pkg
 bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_dna: lib/$(REGEX).pkg
+bin/reverse_complement: lib/$(NUM_CPU).pkg lib/$(CROSSBEAM).pkg lib/$(LIBC).pkg
 
 diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 	mkdir -p diff

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
 RAYON ?= rayon-0.6
 ORDERMAP ?= ordermap-0.2.7
 CROSSBEAM ?= crossbeam-0.2
-LIBC ?= libc-0.2
+MEMCHR ?= memchr-1.0
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -30,7 +30,7 @@ bin/fasta_redux: lib/$(NUM_CPU).pkg
 bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_dna: lib/$(REGEX).pkg
-bin/reverse_complement: lib/$(NUM_CPU).pkg lib/$(CROSSBEAM).pkg lib/$(LIBC).pkg
+bin/reverse_complement: lib/$(NUM_CPU).pkg lib/$(CROSSBEAM).pkg lib/$(MEMCHR).pkg
 
 diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 	mkdir -p diff

--- a/src/reverse_complement.rs
+++ b/src/reverse_complement.rs
@@ -12,7 +12,6 @@ extern crate libc;
 use std::io::{Read, Write};
 use std::{cmp, io, mem, ptr, slice};
 use std::fs::File;
-use std::os::unix::io::FromRawFd;
 
 struct Tables {
     table8: [u8;1 << 8],
@@ -203,7 +202,7 @@ fn file_size(f: &mut File) -> io::Result<usize> {
 }
 
 fn main() {
-    let mut stdin = unsafe { File::from_raw_fd(0) };
+    let mut stdin = File::open("/dev/stdin").expect("Could not open /dev/stdin");
     let size = file_size(&mut stdin).unwrap_or(1024 * 1024);
     let mut data = Vec::with_capacity(size + 1);
     stdin.read_to_end(&mut data).unwrap();


### PR DESCRIPTION
Rather than process each sequence on one thread, this processes each sequence on `n` threads where `n` is the number of CPU cores. This improves CPU utilization, and reduces running time on `input25000000.txt` by 2–3% on my 4-core desktop.