### PR TITLE
reverse_complement: rayon version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bin/fasta_redux: lib/$(NUM_CPU).pkg
 bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_dna: lib/$(REGEX).pkg
-bin/reverse_complement: lib/$(NUM_CPU).pkg lib/$(CROSSBEAM).pkg lib/$(MEMCHR).pkg
+bin/reverse_complement: lib/$(RAYON).pkg lib/$(MEMCHR).pkg
 
 diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 	mkdir -p diff


### PR DESCRIPTION
This runs about as fast on my computer, but it's shorter and gets rid of the `Iterator` implementations (that needed a fair number `mem::replace` dances which made the code less readable IMO).

Please have a look, thanks!