### PR TITLE
binarytrees: rayon version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 distclean: clean
 	rm -fr bin out tmp lib
 
-bin/binary_trees: lib/$(ARENA).pkg
+bin/binary_trees: lib/$(ARENA).pkg lib/$(RAYON).pkg
 bin/fasta: lib/$(NUM_CPU).pkg
 bin/fasta_redux: lib/$(NUM_CPU).pkg
 bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg


### PR DESCRIPTION
Shaves off about 10-15% of the runtime from 1.281s to 1.083s on my machine (the effect is even more drastic on a server with 16 cores, where the speed up is about 2x since we now parallelize across iterations).