### PR TITLE
mandelbrot: inline and remove LTO from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCES = $(wildcard src/*.rs)
 RUSTC ?= rustc
-RUSTC_FLAGS ?= -C opt-level=3 -C target-cpu=core2 -C lto
+RUSTC_FLAGS ?= -C opt-level=3 -C target-cpu=core2
 RUSTC_FLAGS += -L ./lib
 REGEX ?= regex-0.2.1
 ARENA ?= typed-arena-1.1.0

--- a/src/mandelbrot.rs
+++ b/src/mandelbrot.rs
@@ -90,6 +90,7 @@ impl Mandelbrot8 {
         self.to_byte()
     }
 
+    #[inline]
     fn advance(&mut self, iterations: usize) {
         for _ in 0..iterations {
             self.zi = (self.zr + self.zr) * self.zi + self.ci;


### PR DESCRIPTION
Fixes #50, I think: removing LTO somehow changed LLVM's inlining heuristics and `advance` didn't get inlined anymore. Adding the `#[inline]` annotation brings down the runtime to the same value as LTO.