### PR TITLE
spectralnorm: rayon and de-vectorize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_redux: lib/$(REGEX).pkg
 bin/reverse_complement: lib/$(RAYON).pkg
+bin/spectralnorm: lib/$(RAYON).pkg
 
 diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 	mkdir -p diff

--- a/src/spectralnorm.rs
+++ b/src/spectralnorm.rs
@@ -4,12 +4,12 @@
 // contributed by the Rust Project Developers
 // contributed by Matt Brubeck
 // contributed by TeXitoi
+// modified by Tung Duong
 // contributed by Cristi Cobzarenco (@cristicbz)
-
-#![allow(non_snake_case)]
 
 extern crate rayon;
 use rayon::prelude::*;
+
 
 fn main() {
     let n = std::env::args().nth(1)
@@ -20,33 +20,74 @@ fn main() {
 }
 
 fn spectralnorm(n: usize) -> f64 {
+    // Group all vectors in pairs of two for SIMD convenience.
     assert!(n % 2 == 0, "only even lengths are accepted");
-    let mut u = vec![1.0; n];
-    let mut v = vec![0.0; n];
-    let mut tmp = vec![0.0; n];
+    let mut u = vec![[1.0, 1.0]; n / 2];
+    let mut v = vec![[0.0, 0.0]; n / 2];
+    let mut tmp = vec![[0.0, 0.0]; n / 2];
+
     for _ in 0..10 {
-        mult_AtAv(&u, &mut v, &mut tmp);
-        mult_AtAv(&v, &mut u, &mut tmp);
+        mult_at_av(&u, &mut v, &mut tmp);
+        mult_at_av(&v, &mut u, &mut tmp);
     }
+
     (dot(&u, &v) / dot(&v, &v)).sqrt()
 }
 
-fn mult_AtAv(v: &[f64], out: &mut [f64], tmp: &mut [f64]) {
-    mult(v, tmp, A);
-    mult(tmp, out, |i, j| A(j, i));
+fn mult_at_av(v: &[[f64; 2]], out: &mut [[f64; 2]], tmp: &mut [[f64; 2]]) {
+    mult(v, tmp, a);
+    mult(tmp, out, |i, j| a(j, i));
 }
 
-fn mult<F>(v: &[f64], out: &mut [f64], a: F)
-           where F: Fn(usize, usize) -> f64 + Sync {
+fn mult<F>(v: &[[f64; 2]], out: &mut [[f64; 2]], a: F)
+           where F: Fn([usize; 2], [usize; 2]) -> [f64; 2] + Sync {
+    // Parallelize along the output vector, with each pair of slots as a parallelism unit.
     out.par_iter_mut().enumerate().for_each(|(i, slot)| {
-        *slot = v.iter().enumerate().map(|(j, x)| x / a(i, j)).sum();
+        // We're computing everything in chunks of two so the indces of slot[0] and slot[1] are 2*i
+        // and 2*i + 1.
+        let i = 2 * i;
+        let (i0, i1) = ([i; 2], [i + 1; 2]);
+
+        // Each slot in the pair gets its own sum, which is further computed in two f64 lanes (which
+        // are summed at the end.
+        let (mut sum0, mut sum1) = ([0.0; 2], [0.0; 2]);
+        for (j, x) in v.iter().enumerate() {
+            let j = [2 * j, 2 * j  + 1];
+            div_and_add(x, &a(i0, j), &a(i1, j), &mut sum0, &mut sum1);
+        }
+
+        // Sum the two lanes for each slot.
+        slot[0] = sum0[0] + sum0[1];
+        slot[1] = sum1[0] + sum1[1];
     });
 }
 
-fn A(i: usize, j: usize) -> f64 {
-   ((i + j) * (i + j + 1) / 2 + i + 1) as f64
+fn a(i: [usize; 2], j: [usize; 2]) -> [f64; 2] {
+   [(((i[0] + j[0]) * (i[0] + j[0] + 1) / 2 + i[0] + 1) as f64),
+    (((i[1] + j[1]) * (i[1] + j[1] + 1) / 2 + i[1] + 1) as f64)]
 }
 
-fn dot(v: &[f64], u: &[f64]) -> f64 {
-    u.iter().zip(v).map(|(x, y)| x * y).sum()
+fn dot(v: &[[f64; 2]], u: &[[f64; 2]]) -> f64 {
+    // Vectorised form of dot product: (1) compute dot across two lanes.
+    let r = u.iter()
+             .zip(v)
+             .map(|(x, y)| [x[0] * y[0], x[1] * y[1]])
+             .fold([0.0f64; 2], |s, x| [s[0] + x[0], s[1] + x[1]]);
+
+    // (2) sum the two lanes.
+    r[0] + r[1]
+}
+
+// Hint that this function should not be inlined. Keep the parallelised code tight, and vectorize
+// better.
+#[inline(never)]
+fn div_and_add(x: &[f64; 2],
+               a0: &[f64; 2],
+               a1: &[f64; 2],
+               s0: &mut [f64; 2],
+               s1: &mut [f64; 2]) {
+    s0[0] += x[0] / a0[0];
+    s0[1] += x[1] / a0[1];
+    s1[0] += x[0] / a1[0];
+    s1[1] += x[1] / a1[1];
 }

--- a/src/spectralnorm.rs
+++ b/src/spectralnorm.rs
@@ -4,58 +4,15 @@
 // contributed by the Rust Project Developers
 // contributed by Matt Brubeck
 // contributed by TeXitoi
+// contributed by Cristi Cobzarenco (@cristicbz)
 
 #![allow(non_snake_case)]
 
-use std::thread;
-
-// As std::simd::f64x2 etc. are unstable, we provide a similar interface,
-// expecting llvm to autovectorize its usage.
-#[allow(non_camel_case_types)]
-#[derive(Copy, Clone)]
-struct usizex2(usize, usize);
-impl std::ops::Add for usizex2 {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        usizex2(self.0 + rhs.0, self.1 + rhs.1)
-    }
-}
-impl std::ops::Mul for usizex2 {
-    type Output = Self;
-    fn mul(self, rhs: Self) -> Self {
-        usizex2(self.0 * rhs.0, self.1 * rhs.1)
-    }
-}
-impl std::ops::Div for usizex2 {
-    type Output = Self;
-    fn div(self, rhs: Self) -> Self {
-        usizex2(self.0 / rhs.0, self.1 / rhs.1)
-    }
-}
-impl From<usizex2> for f64x2 {
-    fn from(i: usizex2) -> f64x2 {
-        f64x2(i.0 as f64, i.1 as f64)
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct f64x2(f64, f64);
-impl std::ops::Add for f64x2 {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        f64x2(self.0 + rhs.0, self.1 + rhs.1)
-    }
-}
-impl std::ops::Div for f64x2 {
-    type Output = Self;
-    fn div(self, rhs: Self) -> Self {
-        f64x2(self.0 / rhs.0, self.1 / rhs.1)
-    }
-}
+extern crate rayon;
+use rayon::prelude::*;
 
 fn main() {
-    let n = std::env::args_os().nth(1)
-        .and_then(|s| s.into_string().ok())
+    let n = std::env::args().nth(1)
         .and_then(|n| n.parse().ok())
         .unwrap_or(100);
     let answer = spectralnorm(n);
@@ -75,60 +32,21 @@ fn spectralnorm(n: usize) -> f64 {
 }
 
 fn mult_AtAv(v: &[f64], out: &mut [f64], tmp: &mut [f64]) {
-    mult_Av(v, tmp);
-    mult_Atv(tmp, out);
+    mult(v, tmp, A);
+    mult(tmp, out, |i, j| A(j, i));
 }
 
-fn mult_Av(v: &[f64], out: &mut [f64]) {
-    parallel(out, |start, out| mult(v, out, start, Ax2));
+fn mult<F>(v: &[f64], out: &mut [f64], a: F)
+           where F: Fn(usize, usize) -> f64 + Sync {
+    out.par_iter_mut().enumerate().for_each(|(i, slot)| {
+        *slot = v.iter().enumerate().map(|(j, x)| x / a(i, j)).sum();
+    });
 }
 
-fn mult_Atv(v: &[f64], out: &mut [f64]) {
-    parallel(out, |start, out| mult(v, out, start, |i, j| Ax2(j, i)));
-}
-
-fn mult<F>(v: &[f64], out: &mut [f64], start: usize, a: F)
-           where F: Fn(usizex2, usizex2) -> f64x2 {
-    for (i, slot) in out.iter_mut().enumerate().map(|(i, s)| (i + start, s)) {
-        let mut sum = f64x2(0.0, 0.0);
-        for (j, chunk) in v.chunks(2).enumerate().map(|(j, s)| (2 * j, s)) {
-            let top = f64x2(chunk[0], chunk[1]);
-            let bot = a(usizex2(i, i), usizex2(j, j+1));
-            sum = sum + top / bot;
-        }
-        let f64x2(a, b) = sum;
-        *slot = a + b;
-    }
-}
-
-fn Ax2(i: usizex2, j: usizex2) -> f64x2 {
-    ((i + j) * (i + j + usizex2(1, 1)) / usizex2(2, 2) + i + usizex2(1, 1)).into()
+fn A(i: usize, j: usize) -> f64 {
+   ((i + j) * (i + j + 1) / 2 + i + 1) as f64
 }
 
 fn dot(v: &[f64], u: &[f64]) -> f64 {
-    v.iter().zip(u.iter()).map(|(a, b)| *a * *b).fold(0., |acc, i| acc + i)
-}
-
-struct Racy<T>(T);
-unsafe impl<T: 'static> Send for Racy<T> {}
-
-// Executes a closure in parallel over the given mutable slice. The closure `f`
-// is run in parallel and yielded the starting index within `v` as well as a
-// sub-slice of `v`.
-fn parallel<'a, T, F>(v: &mut [T], ref f: F)
-    where T: 'static + Send + Sync,
-          F: Fn(usize, &mut [T]) + Sync {
-    let size = v.len() / 4 + 1;
-    let jhs = v.chunks_mut(size).enumerate().map(|(i, chunk)| {
-        // Need to convert `f` and `chunk` to something that can cross the task
-        // boundary.
-        let f = Racy(f as *const F as *const usize);
-        let raw = Racy((&mut chunk[0] as *mut T, chunk.len()));
-        thread::spawn(move|| {
-            let f = f.0 as *const F;
-            let raw = raw.0;
-            unsafe { (*f)(i * size, std::slice::from_raw_parts_mut(raw.0, raw.1)) }
-        })
-    }).collect::<Vec<_>>();
-    for jh in jhs { jh.join().unwrap(); }
+    u.iter().zip(v).map(|(x, y)| x * y).sum()
 }


### PR DESCRIPTION
I got rid of all the `f64x2` and `usizex2` structs since the code wouldn't vectorize no matter how hard I tried. Unlike #51, I also completely get rid of chunking, letting rayon do all the work, using `par_iter_mut`.

This speeds up the code a little bit from 1.6s to 1.4s on my laptop