### PR TITLE
reverse_complement: Process input in chunks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
 RAYON ?= rayon-0.6
 ORDERMAP ?= ordermap-0.2.7
 CROSSBEAM ?= crossbeam-0.2
-MEMCHR ?= memchr-1.0
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -30,7 +29,7 @@ bin/fasta_redux: lib/$(NUM_CPU).pkg
 bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_dna: lib/$(REGEX).pkg
-bin/reverse_complement: lib/$(RAYON).pkg lib/$(MEMCHR).pkg
+bin/reverse_complement: lib/$(RAYON).pkg
 
 diff/chameneos_redux.diff: out/chameneos_redux.txt ref/chameneos_redux.txt
 	mkdir -p diff

--- a/src/reverse_complement.rs
+++ b/src/reverse_complement.rs
@@ -7,12 +7,20 @@
 // contributed by Matt Brubeck
 
 extern crate rayon;
-extern crate memchr;
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::{cmp, io};
 use std::fs::File;
 use std::mem::replace;
+
+/// This controls the size of reads from the input. Chosen to match the C entry.
+const READ_SIZE: usize = 16 * 1024;
+
+/// Length of a normal line including the terminating \n.
+const LINE_LEN: usize = 61;
+
+/// Chunks larger than this will be split into separate parallel tasks.
+const SEQUENTIAL_SIZE: usize = 2048;
 
 /// Lookup table to find the complement of a single FASTA code.
 fn build_table() -> [u8; 256] {
@@ -66,12 +74,8 @@ impl<'a, T> SplitOff for &'a mut [T] {
     }
 }
 
-/// Length of a normal line including the terminating \n.
-const LINE_LEN: usize = 61;
-const SEQUENTIAL_SIZE: usize = 2048;
-
 /// Compute the reverse complement for two contiguous chunks without line breaks.
-fn reverse_complement_chunk(left: &mut [u8], right: &mut [u8], table: &[u8; 256]) {
+fn reverse_chunks(left: &mut [u8], right: &mut [u8], table: &[u8; 256]) {
     for (x, y) in left.iter_mut().zip(right.iter_mut().rev()) {
         *y = table[replace(x, table[*y as usize]) as usize];
     }
@@ -79,48 +83,49 @@ fn reverse_complement_chunk(left: &mut [u8], right: &mut [u8], table: &[u8; 256]
 
 /// Compute the reverse complement on chunks from opposite ends of a sequence.
 ///
-/// `left` must start at the beginning of a line. If there are an odd number of bytes, `right`
-/// will initially be 1 byte longer than `left`; otherwise they will have equal lengths.
+/// `left` must start at the beginning of a line. If there are an odd number of
+/// bytes, `right` will initially be 1 byte longer than `left`; otherwise they
+/// will have equal lengths.
 fn reverse_complement_left_right(mut left: &mut [u8],
                                  mut right: &mut [u8],
                                  trailing_len: usize,
                                  table: &[u8; 256]) {
     let len = left.len();
     if len <= SEQUENTIAL_SIZE {
-        // Each iteration swaps one line from the start of the sequence with one from the end.
+        // Each iteration swaps one line from the start of the sequence with one
+        // from the end.
         while left.len() > 0  || right.len() > 0 {
             // Get the chunk up to the newline in `right`.
             let mut a = left.split_off_left(trailing_len);
             let mut b = right.split_off_right(trailing_len);
+            right.split_off_right(1); // Skip the newline in `right`.
 
-            // If we've reached the middle of the sequence here and there is an odd number of
-            // bytes remaining, the odd one will be on the right.
+            // If we've reached the middle of the sequence here and there is an
+            // odd number of bytes remaining, the odd one will be on the right.
             if b.len() > a.len() {
                 let mid = b.split_off_left(1);
                 mid[0] = table[mid[0] as usize];
             }
-            reverse_complement_chunk(a, b, table);
 
-            // Skip the newline in `right`.
-            right.split_off_right(1);
+            reverse_chunks(a, b, table);
 
             // Get the chunk up to the newline in `left`.
             let n = LINE_LEN - 1 - trailing_len;
             a = left.split_off_left(n);
             b = right.split_off_right(n);
+            left.split_off_left(1); // Skip the newline in `left`.
 
-            // If we've reached the middle of the sequence here and there is an odd number of
-            // bytes remaining, the odd one will now be on the left.
+            // If we've reached the middle of the sequence and there is an odd
+            // number of bytes remaining, the odd one will now be on the left.
             if a.len() > b.len() {
                 let mid = a.split_off_right(1);
                 mid[0] = table[mid[0] as usize]
             }
-            reverse_complement_chunk(a, b, table);
 
-            // Skip the newline in `left`.
-            left.split_off_left(1);
+            reverse_chunks(a, b, table);
         }
     } else {
+        // Divide large chunks in half and fork them into two parallel tasks.
         let line_count = len / LINE_LEN;
         let mid = line_count / 2 * LINE_LEN; // Split on a whole number of lines.
 
@@ -133,41 +138,49 @@ fn reverse_complement_left_right(mut left: &mut [u8],
 
 /// Compute the reverse complement of one sequence.
 fn reverse_complement(seq: &mut [u8], table: &[u8; 256]) {
-    let len = seq.len() - 1;
-    let seq = &mut seq[..len]; // Drop the last newline
+    let len = seq.len();
     let trailing_len = len % LINE_LEN;
     let (left, right) = seq.split_at_mut(len / 2);
     reverse_complement_left_right(left, right, trailing_len, table);
 }
 
-fn file_size(f: &mut File) -> io::Result<usize> {
-    Ok(f.metadata()?.len() as usize)
-}
+/// Read sequences from stdin and print the reverse complement to stdout.
+fn run() -> io::Result<()> {
+    let stdin = File::open("/dev/stdin")?;
+    let size = stdin.metadata()?.len() as usize;
+    let mut input = BufReader::with_capacity(READ_SIZE, stdin);
 
-/// Locate each DNA sequence in the input file and reverse it.
-fn split_and_reverse<'a>(data: &mut [u8], table: &[u8; 256]) {
-    let data = match memchr::memchr(b'\n', data) {
-        Some(i) => &mut data[i + 1..],
-        None => return,
-    };
+    // Read the input, splitting it into sequences.
+    let mut buf = Vec::with_capacity(size);
+    let mut seqs = vec![];
+    loop {
+        // Read the header line.
+        input.read_until(b'\n', &mut buf)?;
+        let seq_start = buf.len();
+        // Read sequence data.
+        input.read_until(b'>', &mut buf)?;
 
-    match memchr::memchr(b'>', data) {
-        Some(i) => {
-            let (head, tail) = data.split_at_mut(i);
-            rayon::join(|| reverse_complement(head, table),
-                        || split_and_reverse(tail, table));
+        let len = buf.len();
+        if buf[len - 1] == b'>' {
+            // Found the start of a new sequence.
+            seqs.push(seq_start..len - 2); // exclude "\n>"
+        } else {
+            // Reached the end of the input.
+            seqs.push(seq_start..len - 1); // exclude "\n"
+            break
         }
-        None => reverse_complement(data, table),
-    };
+    }
+
+    // Compute the reverse complements of each sequence.
+    let table = build_table();
+    for seq in seqs {
+        reverse_complement(&mut buf[seq], &table);
+    }
+
+    // Print the result.
+    io::stdout().write_all(&buf)
 }
 
 fn main() {
-    let mut stdin = File::open("/dev/stdin").expect("Could not open /dev/stdin");
-    let size = file_size(&mut stdin).unwrap_or(1024 * 1024);
-    let mut data = Vec::with_capacity(size + 1);
-    stdin.read_to_end(&mut data).unwrap();
-
-    split_and_reverse(&mut data, &build_table());
-    let stdout = io::stdout();
-    stdout.lock().write_all(&data).unwrap();
+    run().unwrap()
 }


### PR DESCRIPTION
The previous reverse_complement submission (#55) was rejected for loading the entire input into memory with a single `read`.  The benchmark description specifies that programs should read "line by line" but existing programs follow this very loosely or not at all.  Isaac clarified that programs should at most read fixed chunks at a time, so I changed the program to use a 16 KB `BufReader` to read from stdin in a way equivalent to the fastest C program.  This change slows the program down, but only slightly (by single-digit percentages on my test machines).

This version has been accepted as [Rust no. 2](http://benchmarksgame.alioth.debian.org/u64q/program.php?test=revcomp&lang=rust&id=2).  I also submitted [an additional entry](http://benchmarksgame.alioth.debian.org/u64q/program.php?test=revcomp&lang=rust&id=3) that reads line-by-line from the `BufReader` but is otherwise identical to this, for comparison purposes.  It is 50% slower than this version.

Aside from the `BufReader` changes, this also adds a few more comments, and wraps some lines to a narrower width.