### PR TITLE
binary-trees reset

### DIFF
--- a/ref/binary_trees.txt
+++ b/ref/binary_trees.txt
@@ -1,6 +1,6 @@
-stretch tree of depth 11	 check: -1
-2048	 trees of depth 4	 check: -2048
-512	 trees of depth 6	 check: -512
-128	 trees of depth 8	 check: -128
-32	 trees of depth 10	 check: -32
-long lived tree of depth 10	 check: -1
+stretch tree of depth 11	 check: 4095
+1024	 trees of depth 4	 check: 31744
+256	 trees of depth 6	 check: 32512
+64	 trees of depth 8	 check: 32704
+16	 trees of depth 10	 check: 32752
+long lived tree of depth 10	 check: 2047

--- a/src/binary_trees.rs
+++ b/src/binary_trees.rs
@@ -5,7 +5,6 @@
 // contributed by Matt Brubeck
 // contributed by TeXitoi
 // contributed by Cristi Cobzarenco
-// *reset*
 
 extern crate typed_arena;
 extern crate rayon;
@@ -37,7 +36,7 @@ fn bottom_up_tree<'r>(arena: &'r Arena<Tree<'r>>, depth: i32)
 }
 
 fn inner(depth: i32, iterations: i32) -> String {
-    let chk = (1 .. iterations + 1).into_par_iter().map(|i| {
+    let chk = (0 .. iterations).into_par_iter().map(|_| {
         let arena = Arena::new();
         let a = bottom_up_tree(&arena, depth);
         item_check(a)


### PR DESCRIPTION
The binary-trees benchmark has been [simplified][1] to prevent certain [bugs][2]. This is the converted program and new output file now found on the benchmarksgame site.

[1]: https://alioth.debian.org/forum/forum.php?thread_id=14996&forum_id=2965&group_id=100815
[2]: https://alioth.debian.org/forum/forum.php?thread_id=14963&forum_id=2965&group_id=100815