### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ SOURCES = $(wildcard src/*.rs)
 RUSTC ?= rustc
 RUSTC_FLAGS ?= -C opt-level=3 -C target-cpu=core2 -C lto
 RUSTC_FLAGS += -L ./lib
-REGEX ?= regex-0.2.1
-ARENA ?= typed-arena-1.1.0
-NUM_CPU ?= num_cpus-1.2.1
-FUTURES_CPUPOOL ?= futures-cpupool-0.1.2
-RAYON ?= rayon-0.7
-ORDERMAP ?= ordermap-0.2.7
-CROSSBEAM ?= crossbeam-0.2
+REGEX ?= regex-1.0.4
+ARENA ?= typed-arena-1.4.1
+NUM_CPU ?= num_cpus-1.8.0
+FUTURES_CPUPOOL ?= futures-cpupool-0.1.8
+RAYON ?= rayon-1.0.2
+INDEXMAP ?= indexmap-1.0.1
+CROSSBEAM ?= crossbeam-0.4.1
 
 version=$(lastword $(subst -,  , $1))
 crate=$(strip $(subst -$(call version, $1),, $1))
@@ -24,10 +24,9 @@ distclean: clean
 	rm -fr bin out tmp lib
 
 bin/binary_trees: lib/$(ARENA).pkg lib/$(RAYON).pkg
-bin/fannkuch: lib/$(RAYON).pkg
 bin/fannkuch_redux: lib/$(RAYON).pkg
 bin/fasta: lib/$(NUM_CPU).pkg
-bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(ORDERMAP).pkg
+bin/k_nucleotide: lib/$(FUTURES_CPUPOOL).pkg lib/$(INDEXMAP).pkg
 bin/mandelbrot: lib/$(RAYON).pkg
 bin/regex_redux: lib/$(REGEX).pkg
 bin/reverse_complement: lib/$(RAYON).pkg

--- a/src/binary_trees.rs
+++ b/src/binary_trees.rs
@@ -26,7 +26,7 @@ fn item_check(tree: &Tree) -> i32 {
 
 fn bottom_up_tree<'r>(arena: &'r Arena<Tree<'r>>, depth: i32)
                   -> &'r Tree<'r> {
-    let mut tree = arena.alloc(Tree { children: None });
+    let tree = arena.alloc(Tree { children: None });
     if depth > 0 {
         let right = bottom_up_tree(arena, depth - 1);
         let left = bottom_up_tree(arena, depth - 1);

--- a/src/k_nucleotide.rs
+++ b/src/k_nucleotide.rs
@@ -7,14 +7,14 @@
 
 extern crate futures;
 extern crate futures_cpupool;
-extern crate ordermap;
+extern crate indexmap;
 
 use std::sync::Arc;
 use std::hash::{Hasher, BuildHasherDefault};
 use futures::Future;
 use futures_cpupool::CpuPool;
 use Item::*;
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 struct NaiveHasher(u64);
 impl Default for NaiveHasher {
@@ -34,7 +34,7 @@ impl Hasher for NaiveHasher {
     }
 }
 type NaiveBuildHasher = BuildHasherDefault<NaiveHasher>;
-type NaiveHashMap<K, V> = OrderMap<K, V, NaiveBuildHasher>;
+type NaiveHashMap<K, V> = IndexMap<K, V, NaiveBuildHasher>;
 type Map = NaiveHashMap<Code, u32>;
 
 #[derive(Hash, PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]


### PR DESCRIPTION
This pull request updates the dependencies to their latest upstream versions.

- Crate `ordermap` was renamed to `indexmap`.
- Removed `bin/fannkuch` target since it didn't exist.
- Didn't notice any performance differences.