### PR TITLE
remove needless #[inline(never)] from spectralnorm

### DIFF
--- a/src/spectralnorm.rs
+++ b/src/spectralnorm.rs
@@ -113,9 +113,6 @@ fn dot(v: &[F64x2], u: &[F64x2]) -> f64 {
     r.sum()
 }
 
-// Hint that this function should not be inlined. Keep the parallelised code tight, and vectorize
-// better.
-#[inline(never)]
 fn div_and_add(x: F64x2,
                a0: F64x2,
                a1: F64x2,


### PR DESCRIPTION
Leonardo on rust-users informed me I left a now needless `#[inline(never)]` annotation in there. Removing this speeds up the code *very* much, it runs twice as fast on my machine. I'll submit.