### PR TITLE
Back out #74

### DIFF
--- a/src/spectralnorm.rs
+++ b/src/spectralnorm.rs
@@ -113,6 +113,9 @@ fn dot(v: &[F64x2], u: &[F64x2]) -> f64 {
     r.sum()
 }
 
+// Hint that this function should not be inlined. Keep the parallelised code tight, and vectorize
+// better.
+#[inline(never)]
 fn div_and_add(x: F64x2,
                a0: F64x2,
                a1: F64x2,


### PR DESCRIPTION
Removing the `#[inline(never)]` was great on my mobile skylake cpu with its beefy caches, but bad on Isaac's poor old Penryn. So let's back out that change again.