### PR TITLE
Use std::fs::read

### DIFF
--- a/src/regex_redux.rs
+++ b/src/regex_redux.rs
@@ -10,26 +10,14 @@
 extern crate regex;
 
 use std::borrow::Cow;
-use std::fs::File;
-use std::io::{self, Read};
+use std::fs;
 use std::sync::Arc;
 use std::thread;
 
 macro_rules! regex { ($re:expr) => { ::regex::bytes::Regex::new($re).unwrap() } }
 
-/// Read the input into memory.
-fn read() -> io::Result<Vec<u8>> {
-    // Pre-allocate a buffer based on the input file size.
-    let mut stdin = File::open("/dev/stdin")?;
-    let size = stdin.metadata()?.len() as usize;
-    let mut buf = Vec::with_capacity(size + 1);
-
-    stdin.read_to_end(&mut buf)?;
-    Ok(buf)
-}
-
 fn main() {
-    let mut seq = read().unwrap();
+    let mut seq = fs::read("/dev/stdin").unwrap();
     let ilen = seq.len();
 
     // Remove headers and newlines.


### PR DESCRIPTION
The optimizations from the `regex_redux` benchmark were added to libstd in rust-lang/rust#47324, so we can now use the standard library function instead of custom code to read a file.